### PR TITLE
nx-compile 2.0

### DIFF
--- a/compiler.test.js
+++ b/compiler.test.js
@@ -5,86 +5,128 @@ const compiler = require('./compiler')
 
 global.prop1 = 3
 global.prop2 = 4
+global.propObj = { nestedProp: 'nestedProp' }
+global.isSecure = true
 const localProp = 1
 
 describe('nx-compile', () => {
-  describe('compileCode', () => {
+  describe('compileCode()', () => {
     it('should throw TypeError on invalid source argument', () => {
-      expect(() => compiler.compileCode({})).to.throw(TypeError)
-      expect(() => compiler.compileCode()).to.throw(TypeError)
-      expect(() => compiler.compileCode(12)).to.throw(TypeError)
+      expect(() => compiler.compileCode({}, {})).to.throw(TypeError)
+      expect(() => compiler.compileCode(undefined, {})).to.throw(TypeError)
+      expect(() => compiler.compileCode(12, {})).to.throw(TypeError)
+    })
+
+    it('should throw TypeError on invalid sandbox argument', () => {
+      expect(() => compiler.compileExpression('prop1 + prop2', 12)).to.throw(TypeError)
+      expect(() => compiler.compileExpression('prop1 + prop2', undefined)).to.throw(TypeError)
+      expect(() => compiler.compileExpression('prop1 + prop2', '')).to.throw(TypeError)
     })
   })
 
-  describe('compileExpression', () => {
+  describe('compileExpression()', () => {
     it('should throw TypeError on invalid source argument', () => {
-      expect(() => compiler.compileExpression({})).to.throw(TypeError)
-      expect(() => compiler.compileExpression()).to.throw(TypeError)
-      expect(() => compiler.compileExpression(12)).to.throw(TypeError)
+      expect(() => compiler.compileCode({}, {})).to.throw(TypeError)
+      expect(() => compiler.compileCode(undefined, {})).to.throw(TypeError)
+      expect(() => compiler.compileCode(12, {})).to.throw(TypeError)
+    })
+
+    it('should throw TypeError on invalid sandbox argument', () => {
+      expect(() => compiler.compileExpression('prop1 + prop2', 12)).to.throw(TypeError)
+      expect(() => compiler.compileExpression('prop1 + prop2', undefined)).to.throw(TypeError)
+      expect(() => compiler.compileExpression('prop1 + prop2', '')).to.throw(TypeError)
     })
   })
 
   describe('returned function (compiled code or expression)', () => {
-    it('should execute in a sandbox', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      const value = expression({prop1: 1, prop2: 2})
-      expect(value).to.equal(3)
+    it('should execute in the context of the sandbox', () => {
+      const expression = compiler.compileExpression('prop1 + prop2', {prop1: 1, prop2: 2})
+      expect(expression()).to.equal(3)
     })
 
-    it('should not expose globals to the sandbox', () => {
-      const expression = compiler.compileExpression('prop1')
-      const value = expression({})
-      expect(value).to.equal(undefined)
+    it('should not expose local variables', () => {
+      const expression = compiler.compileExpression('localProp', {})
+      expect(expression).to.throw(ReferenceError)
     })
 
-    it('should not expose globals inside functions defined in the passed code', () => {
-      const rawCode = '({}).__proto__.evil = function() { return prop1 + prop2 }'
-      const code = compiler.compileCode(rawCode)
-      code({prop1: 1, prop2: 2})
-      expect(({}).evil()).to.equal(3)
-    })
-
-    it('"this" should be the sandbox instead of the global object', () => {
-      const expression = compiler.compileExpression('this.prop1 + this.prop2')
-      const value = expression({prop1: 1, prop2: 2}, [])
-      expect(value).to.equal(3)
-    })
-
-    it('should expose specified globals to the sandbox', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      const value = expression({}, ['prop1', 'prop2'])
-      expect(value).to.equal(7)
+    it('should expose global variables', () => {
+      const expression = compiler.compileExpression('prop1 + prop2', {})
+      expect(expression()).to.equal(7)
     })
 
     it('should favour sandbox variables over global ones', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      const value = expression({prop1: 1, prop2: 2}, ['prop1', 'prop2'])
-      expect(value).to.equal(3)
+      const expression = compiler.compileExpression('prop1 + prop2', {prop1: 1, prop2: 2})
+      expect(expression()).to.equal(3)
     })
 
-    it('should expose all globals to the sandbox if true is passed as second arg', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      const value = expression({}, true)
-      expect(value).to.equal(7)
+    it('should set "this" to the sandbox instead of the global object', () => {
+      const expression = compiler.compileExpression('this.prop1 + this.prop2', {prop1: 1, prop2: 2})
+      expect(expression()).to.equal(3)
     })
 
-    it('should not expose closure variables to the sandbox', () => {
-      const expression = compiler.compileExpression('localProp')
-      expect(() => expression({}, ['localProp'])).to.throw(ReferenceError)
+    it('should set "this" to be undefined inside functions defined in the passed code', () => {
+      const code = compiler.compileCode('(function () { return this })()', {})
+      expect(code()).to.equal(undefined)
+    })
+  })
+
+  describe('secure()', () => {
+    before(() => compiler.secure('prop1', 'propObj', 'localProp', 'setTimeout'))
+    beforeEach(() => global.isSecure = true)
+
+    it('should not expose unallowed globals to the sandbox', () => {
+      const expression = compiler.compileExpression('prop2', {})
+      expect(expression()).to.equal(undefined)
     })
 
-    it('should throw TypeError on invalid sandbox argument', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      expect(() => expression()).to.throw(TypeError)
-      expect(() => expression(12)).to.throw(TypeError)
-      expect(() => expression({}, 'string')).to.throw(TypeError)
-      expect(() => expression({}, false)).to.throw(TypeError)
+    it('should expose specified globals to the sandbox', () => {
+      const expression = compiler.compileExpression('prop1', {})
+      expect(expression()).to.equal(3)
     })
 
-    it('should throw TypeError on invalid allowedGlobals argument', () => {
-      const expression = compiler.compileExpression('prop1 + prop2')
-      expect(() => expression({}, 'string')).to.throw(TypeError)
-      expect(() => expression({}, false)).to.throw(TypeError)
+    it('should not expose globals inside functions defined in the passed code', () => {
+      const code = compiler.compileCode('(function () { isSecure = false })()', {})
+      code()
+      expect(global.isSecure).to.be.true
+    })
+
+    it('should not expose globals inside async functions defined in the passed code', () => {
+      const code = compiler.compileCode('setTimeout(() => isSecure = false)', {})
+      code()
+      expect(global.isSecure).to.be.true
+    })
+
+    it('should protect against string manipulation', () => {
+      expect(() => compiler.compileCode('isSecure=false})};function this(){}//', {})).to.throw(SyntaxError)
+      expect(() => compiler.compileCode('})} isSecure = false; {({', {})).to.throw(SyntaxError)
+      expect(global.isSecure).to.be.true
+    })
+
+    it('should deep freeze the prototype of literals', () => {
+      const literals = ['', 0, true, /o/, {}, [], () => {}]
+      for (let literal of literals) {
+        expect(Object.isFrozen(Object.getPrototypeOf(literal))).to.be.true
+      }
+    })
+
+    it('should deep freeze exposed global objects', () => {
+      expect(Object.isFrozen(global.propObj)).to.be.true
+    })
+
+    it('should generally protect against global object mutation', () => {
+      const code1 = compiler.compileCode('("").__proto__.replace = function() {}', {})
+      const code2 = compiler.compileCode('({}).__proto__.toJSON = function() {}', {})
+      const code3 = compiler.compileCode('({}).constructor.create = function() {}', {})
+      const code4 = compiler.compileCode('({}).constructor.prototype.hasOwnProperty = function() {}', {})
+
+      expect(code1).to.throw(TypeError)
+      expect(code2).to.throw(TypeError)
+      expect(code3).to.throw(TypeError)
+      expect(code4).to.throw(TypeError)
+    })
+
+    it('should throw on further secure() calls', () => {
+      expect(() => compiler.secure('prop3')).to.throw(Error)
     })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@risingstack/nx-compile",
-  "version": "1.0.2",
-  "description": "Execution of strings as code in a secure, sandboxed environment.",
+  "version": "2.0.0",
+  "description": "Execution of strings as code in a sandboxed environment with optional security.",
   "main": "compiler.js",
   "scripts": {
     "test": "mocha compiler.test.js",


### PR DESCRIPTION
Proposal for nx-compile 2.0.

Breaking changes:
- The `compileCode()` and `compileExpression()` functions now expect both the string code and the sandbox as arguments. The function returned by them has no parameters.
- Globals can not be exposed by passing an array of global names to the returned function.
- `compileCode()` and `compileExpression()` are unsecure by default. They just add the sandbox to the very beginning of the lookup chain for variables, but expose the whole global object after that.

Features:
- Added the `secure()` function. It secures the compiler by preventing access to the global scope and freezing object literal prototypes (and their prototypes and constructors). Global objects can be optionally exposed by passing their names as a string argument. These objects will also be frozen similarly to object literal prototypes.

Fixes:
- Early closing the `with` block with a single '}' character is now not possible.
- `this` is set to undefined inside functions defined in the passed code. (Because it is executed in strict mode.)
- Other issues are fixed by the changes mentioned in breaking changes and features.

What do you think?
